### PR TITLE
Add `var process = process || {}` to Node.JS's original events.js

### DIFF
--- a/events.js
+++ b/events.js
@@ -1,12 +1,31 @@
-/* vim:set ts=2 sw=2 sts=2 expandtab */
-/*jshint newcap: true undef: true es5: true node: true devel: true
-         forin: true */
-/*global define: true */
-(typeof define !== "function" ? function($){ $(require, exports, module); } : define)(function(require, exports, module, undefined) {
+var process = process || {};
+(function () {
+  "use strict";
 
-"use strict";
+  process.EventEmitter = process.EventEmitter || function () {};
 
-var Extendable = require('https!raw.github.com/Gozala/extendables/v0.2.0/extendables.js').Extendable;
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var EventEmitter = exports.EventEmitter = process.EventEmitter;
 var isArray = Array.isArray;
 
 // By default EventEmitters will print a warning if more than
@@ -15,132 +34,174 @@ var isArray = Array.isArray;
 //
 // Obviously not all Emitters should be limited to 10. This function allows
 // that to be increased. Set to zero for unlimited.
-var MAX_LISTENERS = 10;
-var ERROR_TYEPE = 'error';
+var defaultMaxListeners = 10;
+EventEmitter.prototype.setMaxListeners = function(n) {
+  if (!this._events) this._events = {};
+  this._events.maxListeners = n;
+};
 
-exports.version = "0.2.0";
-exports.EventEmitter = Extendable.extend({
-  setMaxListeners: function setMaxListeners(n) {
-    if (!this._events) this._events = {};
-    this._events.maxListeners = n;
-  },
-  emit: function emit(type) {
-    var args = Array.prototype.slice.call(arguments, 1);
-    var listeners = this.listeners(type);
-    if (type === ERROR_TYEPE && !listeners.length)
-      console.error(args[0]);
 
-    listeners.forEach(function(listener) {
-      try {
-        listener.apply(this, args);
-      } catch (error) {
-        // We emit `error` event if listener threw an exception. If there are
-        // no listeners for `error` events or if listener for `error` event
-        // threw then we dump error directly to the console.
-        if (type !== ERROR_TYEPE && this.listeners(ERROR_TYEPE).length)
-          this.emit(ERROR_TYEPE, error);
-        else
-          console.error(error);
-      }
-    }, this);
-  },
-  on: function on(type, listener) {
-    if (!this._events)
-      this._events = {};
-
-    // To avoid recursion in the case that type == "newListeners"! Before
-    // adding it to the listeners, first emit "newListeners".
-    this.emit('newListener', type, listener);
-
-    var events = this._events[type];
-    if (!events) {
-      // Optimize the case of one listener. Don't need the extra array object.
-      this._events[type] = listener;
-
-    // If listener is an array and if listener is not registered yet.
-    } else if (isArray(events) && !~events.indexOf(listener)) {
-
-      // Check for listener leak
-      if (!events.warned) {
-        var m = events.maxListeners !== undefined ? events.maxListeners :
-                MAX_LISTENERS;
-
-        if (m && m > 0 && events.length > m) {
-          events.warned = true;
-          console.error('warning: possible EventEmitter memory ' +
-                        'leak detected. %d listeners added. ' +
-                        'Use emitter.setMaxListeners() to increase limit.',
-                        this._events[type].length);
-        }
-      }
-
-      events.push(listener);
-
-    // If it's not the same listener adding it
-    } else if (events !== listener) {
-      // Adding the second element, need to change to array.
-      this._events[type] = [events, listener];
-    }
-
-    return this;
-  },
-  once: function once(type, listener) {
-    var self = this;
-    function g() {
-      self.removeListener(type, g);
-      listener.apply(self, arguments);
-    }
-
-    g.listener = listener;
-    self.on(type, g);
-    return this;
-  },
-  removeListener: function removeListener(type, listener) {
-    if ('function' !== typeof listener) {
-      throw new Error('removeListener only takes instances of Function');
-    }
-
-    // does not use listeners(), so no side effect of creating _events[type]
-    if (!this._events || !this._events[type]) return this;
-
-    var list = this._events[type];
-
-    if (isArray(list)) {
-      var position = -1;
-      for (var i = 0, length = list.length; i < length; i++) {
-        if (list[i] === listener ||
-            (list[i].listener && list[i].listener === listener))
-        {
-          position = i;
-          break;
-        }
-      }
-
-      if (position < 0) return this;
-      list.splice(position, 1);
-      if (list.length === 0)
-        delete this._events[type];
-    } else if (list === listener ||
-               (list.listener && list.listener === listener))
+EventEmitter.prototype.emit = function(type) {
+  // If there is no 'error' event listener then throw.
+  if (type === 'error') {
+    if (!this._events || !this._events.error ||
+        (isArray(this._events.error) && !this._events.error.length))
     {
-      delete this._events[type];
+      if (arguments[1] instanceof Error) {
+        throw arguments[1]; // Unhandled 'error' event
+      } else {
+        throw new Error("Uncaught, unspecified 'error' event.");
+      }
+      return false;
     }
-
-    return this;
-  },
-  removeAllListeners: function removeAllListeners(type) {
-    // does not use listeners(), so no side effect of creating _events[type]
-    if (type && this._events && this._events[type]) this._events[type] = null;
-    return this;
-  },
-  listeners: function listeners(type) {
-    if (!this._events) this._events = {};
-    if (!this._events[type]) this._events[type] = [];
-    if (!isArray(this._events[type])) {
-      this._events[type] = [this._events[type]];
-    }
-    return this._events[type].slice(0);
   }
-});
 
-});
+  if (!this._events) return false;
+  var handler = this._events[type];
+  if (!handler) return false;
+
+  if (typeof handler == 'function') {
+    switch (arguments.length) {
+      // fast cases
+      case 1:
+        handler.call(this);
+        break;
+      case 2:
+        handler.call(this, arguments[1]);
+        break;
+      case 3:
+        handler.call(this, arguments[1], arguments[2]);
+        break;
+      // slower
+      default:
+        var args = Array.prototype.slice.call(arguments, 1);
+        handler.apply(this, args);
+    }
+    return true;
+
+  } else if (isArray(handler)) {
+    var args = Array.prototype.slice.call(arguments, 1);
+
+    var listeners = handler.slice();
+    for (var i = 0, l = listeners.length; i < l; i++) {
+      listeners[i].apply(this, args);
+    }
+    return true;
+
+  } else {
+    return false;
+  }
+};
+
+// EventEmitter is defined in src/node_events.cc
+// EventEmitter.prototype.emit() is also defined there.
+EventEmitter.prototype.addListener = function(type, listener) {
+  if ('function' !== typeof listener) {
+    throw new Error('addListener only takes instances of Function');
+  }
+
+  if (!this._events) this._events = {};
+
+  // To avoid recursion in the case that type == "newListeners"! Before
+  // adding it to the listeners, first emit "newListeners".
+  this.emit('newListener', type, listener);
+
+  if (!this._events[type]) {
+    // Optimize the case of one listener. Don't need the extra array object.
+    this._events[type] = listener;
+  } else if (isArray(this._events[type])) {
+
+    // If we've already got an array, just append.
+    this._events[type].push(listener);
+
+    // Check for listener leak
+    if (!this._events[type].warned) {
+      var m;
+      if (this._events.maxListeners !== undefined) {
+        m = this._events.maxListeners;
+      } else {
+        m = defaultMaxListeners;
+      }
+
+      if (m && m > 0 && this._events[type].length > m) {
+        this._events[type].warned = true;
+        console.error('(node) warning: possible EventEmitter memory ' +
+                      'leak detected. %d listeners added. ' +
+                      'Use emitter.setMaxListeners() to increase limit.',
+                      this._events[type].length);
+        console.trace();
+      }
+    }
+  } else {
+    // Adding the second element, need to change to array.
+    this._events[type] = [this._events[type], listener];
+  }
+
+  return this;
+};
+
+EventEmitter.prototype.on = EventEmitter.prototype.addListener;
+
+EventEmitter.prototype.once = function(type, listener) {
+  var self = this;
+  function g() {
+    self.removeListener(type, g);
+    listener.apply(this, arguments);
+  };
+
+  g.listener = listener;
+  self.on(type, g);
+
+  return this;
+};
+
+EventEmitter.prototype.removeListener = function(type, listener) {
+  if ('function' !== typeof listener) {
+    throw new Error('removeListener only takes instances of Function');
+  }
+
+  // does not use listeners(), so no side effect of creating _events[type]
+  if (!this._events || !this._events[type]) return this;
+
+  var list = this._events[type];
+
+  if (isArray(list)) {
+    var position = -1;
+    for (var i = 0, length = list.length; i < length; i++) {
+      if (list[i] === listener ||
+          (list[i].listener && list[i].listener === listener))
+      {
+        position = i;
+        break;
+      }
+    }
+
+    if (position < 0) return this;
+    list.splice(position, 1);
+    if (list.length == 0)
+      delete this._events[type];
+  } else if (list === listener ||
+             (list.listener && list.listener === listener))
+  {
+    delete this._events[type];
+  }
+
+  return this;
+};
+
+EventEmitter.prototype.removeAllListeners = function(type) {
+  // does not use listeners(), so no side effect of creating _events[type]
+  if (type && this._events && this._events[type]) this._events[type] = null;
+  return this;
+};
+
+EventEmitter.prototype.listeners = function(type) {
+  if (!this._events) this._events = {};
+  if (!this._events[type]) this._events[type] = [];
+  if (!isArray(this._events[type])) {
+    this._events[type] = [this._events[type]];
+  }
+  return this._events[type];
+};
+
+}());


### PR DESCRIPTION
Ender.js and other `require` mechanisms can cope with Node.JS's original events.js as long as `process` is defined.

The only reason `process` is used at all in the Node.JS code is for legacy compatibility with C++ modules, so the change is safe. I've been using it in the browser already, I just want to be able to include it in my Ender.JS modules.
