### PR TITLE
Wrap console.trace for IE 10

### DIFF
--- a/events.js
+++ b/events.js
@@ -145,7 +145,10 @@ EventEmitter.prototype.addListener = function(type, listener) {
                     'leak detected. %d listeners added. ' +
                     'Use emitter.setMaxListeners() to increase limit.',
                     this._events[type].length);
-      console.trace();
+      if (typeof console.trace === 'function') {
+        // not supported in IE 10
+        console.trace();
+      }
     }
   }
 


### PR DESCRIPTION
IE 10 doesn't support console.trace ([source](https://developer.mozilla.org/en-US/docs/Web/API/console.trace#Browser_compatibility)), and will throw an error if you attempt to call it.

I've confirmed that this patch solves the problem in our own unit tests for PouchDB.  See also https://github.com/pouchdb/pouchdb/issues/2198.
