### PR TITLE
fixing license field

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,5 +29,5 @@
   "scripts": {
     "test": "mocha --ui qunit -- tests/index.js && zuul -- tests/index.js"
   },
-  "licenses": "MIT"
+  "license": "MIT"
 }


### PR DESCRIPTION
We have some automated tools for license checking that our legal team uses. Right now your module is getting flagged as un-licensed because of this typo. [See here](https://docs.npmjs.com/files/package.json#license).

:smile: 