### PR TITLE
jspm node support

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,5 +29,12 @@
   "scripts": {
     "test": "mocha --ui qunit -- tests/index.js && zuul -- tests/index.js"
   },
+  "jspm": {
+    "map": {
+      "./events.js": {
+        "node": "@node/events"
+      }
+    }
+  },
   "license": "MIT"
 }


### PR DESCRIPTION
This PR includes the necessary jspm configuration for this package to work in Node with the coming jspm 0.17 release, allowing this single package to provide both client and server support.

I completely understand if you'd rather not support this here, but it will simplify user configuration locally having it in one place. There is no maintenance burden either as I would continue to maintain this personally.

Just let me know if you have any questions at all, and thanks for considering.