### PR TITLE
Add support for AMD, CommonJS and as Bower component.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+npm-debug.log

--- a/History.md
+++ b/History.md
@@ -1,3 +1,7 @@
+# 1.2.0 (2016-07-26)
+
+  - Enable support for AMD, CommonJS and as browser script.
+
 # 1.1.1 (2016-06-22)
 
   - add more context to errors if they are not instanceof Error

--- a/Readme.md
+++ b/Readme.md
@@ -14,6 +14,15 @@ npm install events
 var EventEmitter = require('events').EventEmitter
 ```
 
+## Browser ##
+
+```html
+<script src="/path/to/events.js"></script>
+<script>
+    var myEmitter = new events.EventEmitter();
+</script>
+```
+
 ## Usage ##
 
 See the [node.js event emitter docs](http://nodejs.org/api/events.html)

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,25 @@
+{
+  "name": "events",
+  "description": "Node's event emitter for the browser.",
+  "main": "./events.js",
+  "authors": [
+    "Irakli Gozalishvili <rfobic@gmail.com> (http://jeditoolkit.com)",
+    "Escaux Product Development <product@escaux.com> (http://escaux.com)"
+  ],
+  "license": "MIT",
+  "keywords": [
+    "events",
+    "eventEmitter",
+    "eventDispatcher",
+    "listeners"
+  ],
+  "homepage": "https://github.com/Escaux/events",
+  "ignore": [
+    "**/.*",
+    "package.json",
+    "npm-debug.log",
+    "node_modules",
+    "bower_components",
+    "tests"
+  ]
+}

--- a/events.js
+++ b/events.js
@@ -19,6 +19,19 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+((function (root, factory) {
+  var name = 'events';
+  if (typeof define === 'function' && define.amd) {
+    define(name, [], function () {
+      return factory({});
+    });
+  } else if (typeof module === 'object' && module.exports) {
+    factory(module);
+  } else {
+    root[name] = factory({});
+  }
+})(this, function (module) {
+
 function EventEmitter() {
   this._events = this._events || {};
   this._maxListeners = this._maxListeners || undefined;
@@ -300,3 +313,7 @@ function isObject(arg) {
 function isUndefined(arg) {
   return arg === void 0;
 }
+
+return EventEmitter;
+
+}));

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "events",
   "id": "events",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Node's event emitter for all engines.",
   "keywords": [
     "events",


### PR DESCRIPTION
The main purpose of this is to allow using this module out of the box, without any other packaging system, from the browser.

While doing so, I also added the support of AMD, and a `bower.json` file (I will gladly hand over `nodejs-events` if you accept this merge request).