### PR TITLE
Fix eventNames in engines without `Reflect` + add tests

### DIFF
--- a/.zuul.yml
+++ b/.zuul.yml
@@ -1,13 +1,5 @@
 ui: mocha-qunit
 concurrency: 1
 browsers:
-    - name: chrome
-      version: latest
-    - name: firefox
-      version: latest
-    - name: safari
-      version: 7..latest
-    - name: iphone
-      version: latest
     - name: ie
       version: 8..latest

--- a/events.js
+++ b/events.js
@@ -473,8 +473,11 @@ function listenerCount(type) {
   return 0;
 }
 
+var ownKeys = Object.getOwnPropertySymbols ? function(obj) {
+  return Object.getOwnPropertyNames(obj).concat(Object.getOwnPropertySymbols(obj));
+} : objectKeys;
 EventEmitter.prototype.eventNames = function eventNames() {
-  return this._eventsCount > 0 ? objectKeys(this._events) : [];
+  return this._eventsCount > 0 ? ownKeys(this._events) : [];
 };
 
 // About 1.5x faster than the two-arg version of Array#splice().

--- a/events.js
+++ b/events.js
@@ -474,7 +474,7 @@ function listenerCount(type) {
 }
 
 EventEmitter.prototype.eventNames = function eventNames() {
-  return this._eventsCount > 0 ? Reflect.ownKeys(this._events) : [];
+  return this._eventsCount > 0 ? objectKeys(this._events) : [];
 };
 
 // About 1.5x faster than the two-arg version of Array#splice().

--- a/tests/events-list.js
+++ b/tests/events-list.js
@@ -1,0 +1,22 @@
+'use strict';
+
+require('./common');
+var EventEmitter = require('events');
+var assert = require('assert');
+
+var EE = new EventEmitter();
+var m = function() {};
+EE.on('foo', function() {});
+assert.deepStrictEqual(['foo'], EE.eventNames());
+EE.on('bar', m);
+assert.deepStrictEqual(['foo', 'bar'], EE.eventNames());
+EE.removeListener('bar', m);
+assert.deepStrictEqual(['foo'], EE.eventNames());
+
+if (typeof Symbol !== 'undefined') {
+    var s = Symbol('s');
+    EE.on(s, m);
+    assert.deepStrictEqual(['foo', s], EE.eventNames());
+    EE.removeListener(s, m);
+    assert.deepStrictEqual(['foo'], EE.eventNames());
+}

--- a/tests/events-list.js
+++ b/tests/events-list.js
@@ -14,9 +14,9 @@ EE.removeListener('bar', m);
 assert.deepStrictEqual(['foo'], EE.eventNames());
 
 if (typeof Symbol !== 'undefined') {
-    var s = Symbol('s');
-    EE.on(s, m);
-    assert.deepStrictEqual(['foo', s], EE.eventNames());
-    EE.removeListener(s, m);
-    assert.deepStrictEqual(['foo'], EE.eventNames());
+  var s = Symbol('s');
+  EE.on(s, m);
+  assert.deepStrictEqual(['foo', s], EE.eventNames());
+  EE.removeListener(s, m);
+  assert.deepStrictEqual(['foo'], EE.eventNames());
 }

--- a/tests/events-list.js
+++ b/tests/events-list.js
@@ -7,16 +7,23 @@ var assert = require('assert');
 var EE = new EventEmitter();
 var m = function() {};
 EE.on('foo', function() {});
-assert.deepStrictEqual(['foo'], EE.eventNames());
+assert.equal(1, EE.eventNames().length);
+assert.equal('foo', EE.eventNames()[0]);
 EE.on('bar', m);
-assert.deepStrictEqual(['foo', 'bar'], EE.eventNames());
+assert.equal(2, EE.eventNames().length);
+assert.equal('foo', EE.eventNames()[0]);
+assert.equal('bar', EE.eventNames()[1]);
 EE.removeListener('bar', m);
-assert.deepStrictEqual(['foo'], EE.eventNames());
+assert.equal(1, EE.eventNames().length);
+assert.equal('foo', EE.eventNames()[0]);
 
 if (typeof Symbol !== 'undefined') {
   var s = Symbol('s');
   EE.on(s, m);
-  assert.deepStrictEqual(['foo', s], EE.eventNames());
+  assert.equal(2, EE.eventNames().length);
+  assert.equal('foo', EE.eventNames()[0]);
+  assert.equal(s, EE.eventNames()[1]);
   EE.removeListener(s, m);
-  assert.deepStrictEqual(['foo'], EE.eventNames());
+  assert.equal(1, EE.eventNames().length);
+  assert.equal('foo', EE.eventNames()[0]);
 }

--- a/tests/events-list.js
+++ b/tests/events-list.js
@@ -1,7 +1,7 @@
 'use strict';
 
 require('./common');
-var EventEmitter = require('events');
+var EventEmitter = require('../');
 var assert = require('assert');
 
 var EE = new EventEmitter();

--- a/tests/index.js
+++ b/tests/index.js
@@ -12,6 +12,7 @@ var require = function(file) {
 
 require('./add-listeners.js');
 require('./check-listener-leaks.js');
+require('./events-list.js');
 require('./listener-count.js');
 require('./listeners-side-effects.js');
 require('./listeners.js');

--- a/tests/index.js
+++ b/tests/index.js
@@ -21,6 +21,7 @@ require('./modify-in-emit.js');
 require('./num-args.js');
 require('./once.js');
 require('./set-max-listeners-side-effects.js');
+require('./special-event-names.js');
 require('./subclass.js');
 require('./remove-all-listeners.js');
 require('./remove-listeners.js');

--- a/tests/special-event-names.js
+++ b/tests/special-event-names.js
@@ -16,6 +16,7 @@ ee.on('__proto__', handler);
 ee.on('__defineGetter__', handler);
 ee.on('toString', handler);
 
+console.log(ee.eventNames().join(','))
 assert.strictEqual(ee.eventNames().length, 3);
 assert.strictEqual(ee.eventNames()[0], '__proto__');
 assert.strictEqual(ee.eventNames()[1], '__defineGetter__');

--- a/tests/special-event-names.js
+++ b/tests/special-event-names.js
@@ -24,8 +24,8 @@ assert.strictEqual(ee.listeners('__defineGetter__')[0], handler);
 assert.strictEqual(ee.listeners('toString').length, 1);
 assert.strictEqual(ee.listeners('toString')[0], handler);
 
-// Disable __proto__ tests in IE8
-if (typeof navigator === 'undefined' || !/MSIE 8/.test(navigator.userAgent)) {
+// Only run __proto__ tests if that property can actually be set
+if ({ __proto__: 'ok' }.__proto__ === 'ok') {
   assert.strictEqual(ee.eventNames().length, 3);
   assert.strictEqual(ee.eventNames()[2], '__proto__');
   assert.strictEqual(ee.listeners('__proto__').length, 1);

--- a/tests/special-event-names.js
+++ b/tests/special-event-names.js
@@ -7,7 +7,7 @@ var assert = require('assert');
 var ee = new EventEmitter();
 var handler = function() {};
 
-assert.deepStrictEqual(ee.eventNames(), []);
+assert.strictEqual(ee.eventNames().length, 0);
 
 assert.strictEqual(ee._events.hasOwnProperty, undefined);
 assert.strictEqual(ee._events.toString, undefined);
@@ -16,15 +16,17 @@ ee.on('__proto__', handler);
 ee.on('__defineGetter__', handler);
 ee.on('toString', handler);
 
-assert.deepStrictEqual(ee.eventNames(), [
-  '__proto__',
-  '__defineGetter__',
-  'toString'
-]);
+assert.strictEqual(ee.eventNames().length, 3);
+assert.strictEqual(ee.eventNames()[0], '__proto__');
+assert.strictEqual(ee.eventNames()[1], '__defineGetter__');
+assert.strictEqual(ee.eventNames()[2], 'toString');
 
-assert.deepStrictEqual(ee.listeners('__proto__'), [handler]);
-assert.deepStrictEqual(ee.listeners('__defineGetter__'), [handler]);
-assert.deepStrictEqual(ee.listeners('toString'), [handler]);
+assert.strictEqual(ee.listeners('__proto__').length, 1);
+assert.strictEqual(ee.listeners('__proto__')[0], handler);
+assert.strictEqual(ee.listeners('__defineGetter__').length, 1);
+assert.strictEqual(ee.listeners('__defineGetter__')[0], handler);
+assert.strictEqual(ee.listeners('toString').length, 1);
+assert.strictEqual(ee.listeners('toString')[0], handler);
 
 ee.on('__proto__', common.mustCall(function(val) {
   assert.strictEqual(val, 1);

--- a/tests/special-event-names.js
+++ b/tests/special-event-names.js
@@ -12,29 +12,32 @@ assert.strictEqual(ee.eventNames().length, 0);
 assert.strictEqual(ee._events.hasOwnProperty, undefined);
 assert.strictEqual(ee._events.toString, undefined);
 
-ee.on('__proto__', handler);
 ee.on('__defineGetter__', handler);
 ee.on('toString', handler);
+ee.on('__proto__', handler);
 
-console.log(ee.eventNames().join(','))
-assert.strictEqual(ee.eventNames().length, 3);
-assert.strictEqual(ee.eventNames()[0], '__proto__');
-assert.strictEqual(ee.eventNames()[1], '__defineGetter__');
-assert.strictEqual(ee.eventNames()[2], 'toString');
+assert.strictEqual(ee.eventNames()[0], '__defineGetter__');
+assert.strictEqual(ee.eventNames()[1], 'toString');
 
-assert.strictEqual(ee.listeners('__proto__').length, 1);
-assert.strictEqual(ee.listeners('__proto__')[0], handler);
 assert.strictEqual(ee.listeners('__defineGetter__').length, 1);
 assert.strictEqual(ee.listeners('__defineGetter__')[0], handler);
 assert.strictEqual(ee.listeners('toString').length, 1);
 assert.strictEqual(ee.listeners('toString')[0], handler);
 
-ee.on('__proto__', common.mustCall(function(val) {
-  assert.strictEqual(val, 1);
-}));
-ee.emit('__proto__', 1);
+// Disable __proto__ tests in IE8
+if (typeof navigator === 'undefined' || !/MSIE 8/.test(navigator.userAgent)) {
+  assert.strictEqual(ee.eventNames().length, 3);
+  assert.strictEqual(ee.eventNames()[2], '__proto__');
+  assert.strictEqual(ee.listeners('__proto__').length, 1);
+  assert.strictEqual(ee.listeners('__proto__')[0], handler);
 
-process.on('__proto__', common.mustCall(function(val) {
-  assert.strictEqual(val, 1);
-}));
-process.emit('__proto__', 1);
+  ee.on('__proto__', common.mustCall(function(val) {
+    assert.strictEqual(val, 1);
+  }));
+  ee.emit('__proto__', 1);
+
+  process.on('__proto__', common.mustCall(function(val) {
+    assert.strictEqual(val, 1);
+  }));
+  process.emit('__proto__', 1);
+}

--- a/tests/special-event-names.js
+++ b/tests/special-event-names.js
@@ -1,0 +1,37 @@
+'use strict';
+
+var common = require('./common');
+var EventEmitter = require('events');
+var assert = require('assert');
+
+var ee = new EventEmitter();
+var handler = function() {};
+
+assert.deepStrictEqual(ee.eventNames(), []);
+
+assert.strictEqual(ee._events.hasOwnProperty, undefined);
+assert.strictEqual(ee._events.toString, undefined);
+
+ee.on('__proto__', handler);
+ee.on('__defineGetter__', handler);
+ee.on('toString', handler);
+
+assert.deepStrictEqual(ee.eventNames(), [
+  '__proto__',
+  '__defineGetter__',
+  'toString'
+]);
+
+assert.deepStrictEqual(ee.listeners('__proto__'), [handler]);
+assert.deepStrictEqual(ee.listeners('__defineGetter__'), [handler]);
+assert.deepStrictEqual(ee.listeners('toString'), [handler]);
+
+ee.on('__proto__', common.mustCall(function(val) {
+  assert.strictEqual(val, 1);
+}));
+ee.emit('__proto__', 1);
+
+process.on('__proto__', common.mustCall(function(val) {
+  assert.strictEqual(val, 1);
+}));
+process.emit('__proto__', 1);

--- a/tests/special-event-names.js
+++ b/tests/special-event-names.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var common = require('./common');
-var EventEmitter = require('events');
+var EventEmitter = require('../');
 var assert = require('assert');
 
 var ee = new EventEmitter();


### PR DESCRIPTION
porting events-list and special-event-names tests. Symbol tests are only run in environments with Symbols.