### PR TITLE
Set browser test concurrency to one

### DIFF
--- a/.zuul.yml
+++ b/.zuul.yml
@@ -1,4 +1,5 @@
 ui: mocha-qunit
+concurrency: 1
 browsers:
     - name: chrome
       version: latest


### PR DESCRIPTION
This is a first stab at getting the browser tests to run again. I've had similar problems in the Saucelabs browser tests of [@feathersjs/client](https://github.com/feathersjs/client) and throttling did help (it does use the Saucelabs provided Grunt task and tunnel though).

This PR may not pass since it doesn't have access to the Saucelabs environment variables but it is worth a try. Alternatives may be

- Use [ngrok](https://ngrok.com/) for localhost tunneling instead of localtunnel
- Use Grunt Saucelabs with the built in tunnel (this might require restructuring the tests a little)