### PR TITLE
Add universal event listeners

### DIFF
--- a/events.js
+++ b/events.js
@@ -195,9 +195,9 @@ EventEmitter.prototype.emit = function emit(type) {
           args[i - 1] = arguments[i];
         emitMany(handler, isFn, this, args);
     }
-    if (!universalHandler) //just no universal handler
+    if (!universalHandler || type == '*') //just no universal handler
       return true; //true, because at least one normal handler was triggered
-      
+
   } else if (!universalHandler) { //no handler and universal handlers
     return false; //false, because no normal handler was triggered
   }


### PR DESCRIPTION
# Changes
+ Listeners listening to the event `'*'` getting triggered by **every emitted event**.
+ The handler function of a listener listening to '*' gets the actually emitted event as **first argument**.
+ `.emit` only returns true if at least one non-universal listener was triggered.
+ `.emit('*'` triggers each listeners listening to `'*'` only once. _(the non-universal listener without the actually emitted event as first argument)_

# Examples
```javascript
emitter.on('foo', function() {
  console.log("foo");
  console.log(arguments);
})

emitter.on('*', function() {
  console.log("*");
  console.log(arguments);
})

console.log(emitter.emit('foo', 'bar1', 'bar2', 'bar3'));

//Output:
//foo
//[Arguments] { '0': 'bar1', '1': 'bar2', '2': 'bar3' }
//*
//[Arguments] { '0': 'foo', '1': 'bar1', '2': 'bar2', '3': 'bar3' }
//true
```

```javascript
emitter.on('*', function() {
  console.log("*");
  console.log(arguments);
})

console.log(emitter.emit('foo', 'bar1', 'bar2', 'bar3'));

//Output:
//*
//[Arguments] { '0': 'foo', '1': 'bar1', '2': 'bar2', '3': 'bar3' }
//false
```
```javascript
emitter.on('foo', function() {
  console.log("foo");
  console.log(arguments);
})

emitter.on('*', function() {
  console.log("*");
  console.log(arguments);
})

console.log(emitter.emit('foobar', 'bar1', 'bar2', 'bar3'));

//Output:
//*
//[Arguments] { '0': 'foobar', '1': 'bar1', '2': 'bar2', '3': 'bar3' }
//false
```
```javascript
emitter.on('*', function() {
  console.log("*");
  console.log(arguments);
})

console.log(emitter.emit('*', 'bar1', 'bar2', 'bar3'));

//Output:
//*
//[Arguments] { '0': 'bar1', '1': 'bar2', '2': 'bar3' }
//true
```