### PR TITLE
Add universal event listeners

### DIFF
--- a/events.js
+++ b/events.js
@@ -122,20 +122,35 @@ EventEmitter.prototype.emit = function emit(type) {
   }
 
   var handler = events[type];
+  var universalHandler = events['*'];
 
-  if (handler === undefined)
-    return false;
-
-  if (typeof handler === 'function') {
-    ReflectApply(handler, this, args);
-  } else {
-    var len = handler.length;
-    var listeners = arrayClone(handler, len);
-    for (var i = 0; i < len; ++i)
-      ReflectApply(listeners[i], this, args);
+  //trigger normal listeners
+  if (handler && type != '*'){
+    if (typeof handler === 'function') {
+      ReflectApply(handler, this, args);
+    } else {
+      var len = handler.length;
+      var listeners = arrayClone(handler, len);
+      for (var i = 0; i < len; ++i)
+        ReflectApply(listeners[i], this, args);
+    }
   }
 
-  return true;
+  //trigger universal listeners
+  if(universalHandler){
+    args.unshift(type);
+    if (typeof universalHandler === 'function') {
+      ReflectApply(universalHandler, this, args);
+    } else {
+      var len = universalHandler.length;
+      var listeners = arrayClone(universalHandler, len);
+      for (var i = 0; i < len; ++i)
+        ReflectApply(listeners[i], this, args);
+    }
+  }
+
+  if(handler) {return true}
+  else {return false}
 };
 
 function _addListener(target, type, listener, prepend) {


### PR DESCRIPTION
 **Applies changes from pull request  #53 on branch [node-10](https://github.com/Gozala/events/tree/node-10) (24th Mai 2018).**

# Remained added features from #53 
+ Listeners listening to the event `'*'` getting triggered by **every emitted event**.
+ The handler function of a listener listening to '*' gets the actually emitted event as **first argument**.
+ `.emit` only returns true if at least one non-universal listener was triggered.

# Changes
+ `.emit('*'` triggers each listeners listening to `'*'` only once. _(with the actually emitted event as first argument)_

# Examples
```javascript
emitter.on('foo', function() {
  console.log("foo");
  console.log(arguments);
})

emitter.on('*', function() {
  console.log("*");
  console.log(arguments);
})

console.log(emitter.emit('foo', 'bar1', 'bar2', 'bar3'));

//Output:
//foo
//[Arguments] { '0': 'bar1', '1': 'bar2', '2': 'bar3' }
//*
//[Arguments] { '0': 'foo', '1': 'bar1', '2': 'bar2', '3': 'bar3' }
//true
```

```javascript
emitter.on('*', function() {
  console.log("*");
  console.log(arguments);
})

console.log(emitter.emit('foo', 'bar1', 'bar2', 'bar3'));

//Output:
//*
//[Arguments] { '0': 'foo', '1': 'bar1', '2': 'bar2', '3': 'bar3' }
//false
```
```javascript
emitter.on('foo', function() {
  console.log("foo");
  console.log(arguments);
})

emitter.on('*', function() {
  console.log("*");
  console.log(arguments);
})

console.log(emitter.emit('foobar', 'bar1', 'bar2', 'bar3'));

//Output:
//*
//[Arguments] { '0': 'foobar', '1': 'bar1', '2': 'bar2', '3': 'bar3' }
//false
```
```javascript
emitter.on('*', function() {
  console.log("*");
  console.log(arguments);
})

console.log(emitter.emit('*', 'bar1', 'bar2', 'bar3'));

//Output:
//*
//[Arguments] { '0': '*', '1': 'bar1', '2': 'bar2', '3': 'bar3' }
//true
```