### PR TITLE
 Fixup unhandled error behavior to properly mimic node

### DIFF
--- a/events.js
+++ b/events.js
@@ -116,6 +116,14 @@ EventEmitter.prototype.getMaxListeners = function getMaxListeners() {
   return $getMaxListeners(this);
 };
 
+function rethrowToConsole(er) {
+  setTimeout(function() {
+      // Note: The comments on the `throw` lines are intentional, they show
+      // up in Node's output if this results in an unhandled exception.
+      throw er; // Unhandled 'error' event  }, 0);
+  }, 0);
+}
+
 EventEmitter.prototype.emit = function emit(type) {
   var args = [];
   for (var i = 1; i < arguments.length; i++) args.push(arguments[i]);
@@ -133,16 +141,13 @@ EventEmitter.prototype.emit = function emit(type) {
     if (args.length > 0)
       er = args[0];
     if (er instanceof Error) {
-      // Note: The comments on the `throw` lines are intentional, they show
-      // up in Node's output if this results in an unhandled exception.
-      throw er; // Unhandled 'error' event
+      rethrowToConsole(er);
+      return;
     }
     // At least give some kind of context to the user
     var err = new Error('Unhandled error.' + (er ? ' (' + er.message + ')' : ''));
     err.context = er;
-    setTimeout(function() {
-      throw err;
-    }, 0);
+    rethrowToConsole(err);
     return;
   }
 

--- a/events.js
+++ b/events.js
@@ -117,7 +117,7 @@ EventEmitter.prototype.getMaxListeners = function getMaxListeners() {
 };
 
 function rethrowToConsole(er) {
-  setTimeout(function() {
+  setTimeout(function unhandledError() {
       // Note: The comments on the `throw` lines are intentional, they show
       // up in Node's output if this results in an unhandled exception.
       throw er; // Unhandled 'error' event  }, 0);

--- a/events.js
+++ b/events.js
@@ -140,7 +140,10 @@ EventEmitter.prototype.emit = function emit(type) {
     // At least give some kind of context to the user
     var err = new Error('Unhandled error.' + (er ? ' (' + er.message + ')' : ''));
     err.context = er;
-    throw err; // Unhandled 'error' event
+    setTimeout(function() {
+      throw err;
+    }, 0);
+    return;
   }
 
   var handler = events[type];


### PR DESCRIPTION
Rethrow on setTimeout to clear the stack before throwing. This forces the error onto the console.
It also prevents it from being erroneously thrown back to the caller that reported the error with EventEmitter.emit('error',...)