### PR TITLE
Update package metadata links

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,11 +11,11 @@
   "author": "Irakli Gozalishvili <rfobic@gmail.com> (http://jeditoolkit.com)",
   "repository": {
     "type": "git",
-    "url": "git://github.com/browserify/events.git",
+    "url": "git+https://github.com/browserify/events.git",
     "web": "https://github.com/browserify/events"
   },
   "bugs": {
-    "url": "http://github.com/browserify/events/issues/"
+    "url": "https://github.com/browserify/events/issues/"
   },
   "main": "./events.js",
   "engines": {


### PR DESCRIPTION
Updates package metadata links to use canonical HTTPS URLs. This is a metadata-only change.